### PR TITLE
Add highlights.scm and minor grammar change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tree-sitter-Solidity"
+description = "Solidity grammar for the tree-sitter parsing library"
+version = "0.0.1"
+keywords = ["incremental", "parsing", "Solidity"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-javascript"
+edition = "2018"
+license = "MIT"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "queries/*",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "0.19.3"
+
+[build-dependencies]
+cc = "1.0"

--- a/bindings/node/binding.cc
+++ b/bindings/node/binding.cc
@@ -1,0 +1,28 @@
+#include "tree_sitter/parser.h"
+#include <node.h>
+#include "nan.h"
+
+using namespace v8;
+
+extern "C" TSLanguage * tree_sitter_Solidity();
+
+namespace {
+
+NAN_METHOD(New) {}
+
+void Init(Local<Object> exports, Local<Object> module) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("Language").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
+  Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
+  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_Solidity());
+
+  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("Solidity").ToLocalChecked());
+  Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
+}
+
+NODE_MODULE(tree_sitter_Solidity_binding, Init)
+
+}  // namespace

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+
+    // If your language uses an external scanner written in C,
+    // then include this block of code:
+
+    /*
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    // If your language uses an external scanner written in C++,
+    // then include this block of code:
+
+    /*
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    cpp_config.compile("scanner");
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,52 @@
+//! This crate provides Solidity language support for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this language to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! let code = "";
+//! let mut parser = tree_sitter::Parser::new();
+//! parser.set_language(tree_sitter_Solidity::language()).expect("Error loading Solidity grammar");
+//! let tree = parser.parse(code, None).unwrap();
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_Solidity() -> Language;
+}
+
+/// Get the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_Solidity() }
+}
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+// Uncomment these to include any queries that this grammar contains
+
+// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Solidity language");
+    }
+}

--- a/grammar.js
+++ b/grammar.js
@@ -29,7 +29,7 @@ const PREC = {
 
 // The following is the core grammar for Solidity. It accepts Solidity smart contracts between the versions 0.4.x and 0.7.x.
 module.exports = grammar({
-    name: 'Solidity',
+    name: 'solidity',
 
     // Extras is an array of tokens that is allowed anywhere in the document.
     extras: $ => [
@@ -644,7 +644,7 @@ module.exports = grammar({
             $.binary_expression,
             $.unary_expression,
             $.update_expression,
-            $.call_expresion,
+            $.call_expression,
             // TODO: $.function_call_options_expression,
             $.payable_conversion_expression,
             $.meta_type_expression,
@@ -660,7 +660,7 @@ module.exports = grammar({
             $.member_expression,
             $.array_access,
             $.slice_access,
-            $._primitive_type,
+            $.primitive_type,
             $.assignment_expression,
             $.augmented_assignment_expression,
             $._user_defined_type,
@@ -671,8 +671,8 @@ module.exports = grammar({
             $.new_expression,
         ),
 
-        // TODO: back this up with official dcumentation
-        type_cast_expression: $ => prec.left(seq($._primitive_type, '(', $._expression,')')),
+        // TODO: back this up with official documentation
+        type_cast_expression: $ => prec.left(seq($.primitive_type, '(', $._expression,')')),
 
         ternary_expression: $ => prec.left(seq($._expression, "?", $._expression, ':', $._expression)),
 
@@ -811,7 +811,7 @@ module.exports = grammar({
             field('right', $._expression)
         )),
           
-        call_expresion: $ => seq(
+        call_expression: $ => seq(
             seq($._expression, $._call_arguments),
         ),
 
@@ -819,7 +819,7 @@ module.exports = grammar({
         meta_type_expression: $ => seq('type', '(', $.type_name, ')'),
         
         type_name: $ => prec(0, choice(
-            $._primitive_type,
+            $.primitive_type,
             $._user_defined_type,
             $._mapping,
             $._array_type,
@@ -871,11 +871,11 @@ module.exports = grammar({
         ),
 
         _mapping_key: $ => choice(
-            $._primitive_type,
+            $.primitive_type,
             $._user_defined_type
         ),
 
-        _primitive_type: $ => prec.left(choice(
+        primitive_type: $ => prec.left(choice(
             seq('address', optional('payable')),
             'bool',
             'string',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tree-sitter-solidity",
   "version": "1.0.5",
   "description": "A tree sitter parser for Solidity",
-  "main": "index.js",
+  "main": "bindings/node",
   "scripts": {
     "test": "tree-sitter generate && tree-sitter test"
   },
@@ -13,5 +13,17 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.16.9"
-  }
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.sol",
+      "file-types": [
+        "sol"
+      ],
+      "highlights": [
+        "queries/highlights.scm"
+      ],
+      "injection-regex": "^(sol|solidity)$"
+    }
+  ]
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,189 @@
+(comment) @comment
+
+; Pragma
+(pragma_directive) @tag
+(pragma_directive ">=" @tag)
+(pragma_directive "<=" @tag)
+(pragma_directive "=" @tag)
+(pragma_directive "~" @tag)
+(pragma_directive "^" @tag)
+
+
+; Literals
+[
+ (string)
+ (hex_string_literal)
+ (unicode_string_literal)
+ (yul_string_literal)
+] @string
+[
+ (number_literal)
+ (yul_decimal_number)
+ (yul_hex_number)
+] @number
+[
+ (true)
+ (false)
+] @constant.builtin
+
+
+; Type
+(type_name) @type
+(primitive_type) @type
+(struct_declaration struct_name: (identifier) @type)
+(enum_declaration enum_type_name: (identifier) @type)
+; Color payable in payable address conversion as type and not as keyword
+(payable_conversion_expression "payable" @type)
+(emit_statement . (identifier) @type)
+; Handles ContractA, ContractB in function foo() override(ContractA, contractB) {} 
+(override_specifier (identifier) @type)
+; Ensures that delimiters in mapping( ... => .. ) are not colored like types
+(type_name "(" @punctuation.bracket "=>" @punctuation.delimiter ")" @punctuation.bracket)
+
+
+
+; Functions and parameters
+
+(function_definition
+  function_name:  (identifier) @function)
+(modifier_definition
+  name:  (identifier) @function)
+(yul_evm_builtin) @function.builtin
+
+; Use contructor coloring for special functions
+(constructor_definition "constructor" @constructor)
+(fallback_receive_definition "receive" @constructor)
+(fallback_receive_definition "fallback" @constructor)
+
+(modifier_invocation (identifier) @function)
+
+; Handles expressions like structVariable.g();
+(call_expression . (member_expression (property_identifier) @function.method))
+
+; Handles expressions like g();
+(call_expression . (identifier) @function)
+
+; Function parameters
+(event_paramater name: (identifier) @variable.parameter)
+(function_definition
+  name:  (identifier) @variable.parameter)
+
+; Yul functions
+(yul_function_call function: (yul_identifier) @function)
+
+; Yul function parameters
+(yul_function_definition . (yul_identifier) @function (yul_identifier) @variable.parameter)
+
+(meta_type_expression "type" @keyword)
+
+(member_expression (property_identifier) @property)
+(property_identifier) @property
+(struct_expression ((identifier) @property . ":"))
+(enum_value) @property
+
+
+; Keywords
+[
+ "pragma"
+ "import"
+ "contract"
+ "interface"
+ "library"
+ "is"
+ "struct"
+ "enum"
+ "event"
+ "using"
+ "assembly"
+ "switch"
+ "case"
+ "default"
+ "break"
+ "continue"
+ "if"
+ "else"
+ "for"
+ "while"
+ "do"
+ "try"
+ "catch"
+ "return"
+ "emit"
+ "public"
+ "internal"
+ "private"
+ "external"
+ "pure"
+ "view"
+ "payable"
+ "modifier"
+ "returns"
+ "memory"
+ "storage"
+ "calldata"
+ "function"
+ "var"
+ (constant)
+ (virtual)
+ (override_specifier)
+ (yul_leave)
+] @keyword
+
+(import_directive "as" @keyword)
+(import_directive "from" @keyword)
+(event_paramater "indexed" @keyword)
+
+; Punctuation
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+
+; Operators
+
+[
+  "&&"
+  "||"
+  ">>"
+  ">>>"
+  "<<"
+  "&"
+  "^"
+  "|"
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "**"
+  "<"
+  "<="
+  "=="
+  "!="
+  "!=="
+  ">="
+  ">"
+  "!"
+  "~"
+  "-"
+  "+"
+  "delete"
+  "new"
+  "++"
+  "--"
+] @operator
+
+(identifier) @variable
+(yul_identifier) @variable

--- a/test/corpus/constructor.txt
+++ b/test/corpus/constructor.txt
@@ -30,7 +30,7 @@ contract Example {
     name: (identifier)
     body: (contract_body 
         (constructor_definition 
-            type: (type_name) name: (identifier)
+            type: (type_name (primitive_type)) name: (identifier)
             type: (type_name (identifier) (identifier)) name: (identifier)
             body: (function_body)))))
 
@@ -50,7 +50,7 @@ contract Example {
     name: (identifier)
     body: (contract_body 
         (constructor_definition 
-            type: (type_name) name: (identifier)
+            type: (type_name (primitive_type)) name: (identifier)
             type: (type_name (identifier) (identifier)) name: (identifier)
             (modifier_invocation (identifier))
             body: (function_body)))))

--- a/test/corpus/event.txt
+++ b/test/corpus/event.txt
@@ -49,7 +49,7 @@ contract Example {
     body: (contract_body
         (event_definition
             name: (identifier)
-            (event_paramater type: (type_name))))))
+            (event_paramater type: (type_name (primitive_type)))))))
 
 ====================
 Event parameters
@@ -68,14 +68,14 @@ contract Example {
         (event_definition
             name: (identifier)
 
-            (event_paramater type: (type_name))
+            (event_paramater type: (type_name (primitive_type)))
             
             (event_paramater 
-              type: (type_name)
+              type: (type_name (primitive_type))
               name: (identifier))
 
-            (event_paramater type: (type_name))
+            (event_paramater type: (type_name (primitive_type)))
             
             (event_paramater 
-              type: (type_name)
+              type: (type_name (primitive_type))
               name: (identifier))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -18,7 +18,7 @@ contract Example {
         (function_definition
          function_name: (identifier)
          body: (function_body 
-            (variable_declaration_statement (variable_declaration (type_name) name: (identifier)))
+            (variable_declaration_statement (variable_declaration (type_name (primitive_type)) name: (identifier)))
             (expression_statement (member_expression object: (identifier) property: (property_identifier))))))))
 
 ====================
@@ -139,7 +139,7 @@ contract Example {
         (function_definition
          function_name: (identifier)
          body: (function_body 
-            (expression_statement (call_expresion 
+            (expression_statement (call_expression 
             (identifier) 
             (identifier))))))))
 
@@ -296,7 +296,8 @@ contract Example {
     (expression_statement (inline_array_expression  (number_literal) (number_literal)))
     (expression_statement (identifier)) 
     (expression_statement (number_literal))
-    (expression_statement (member_expression (identifier) (property_identifier))) (expression_statement))))))
+    (expression_statement (member_expression (identifier) (property_identifier)))
+    (expression_statement (primitive_type)))))))
 
 
 ====================
@@ -337,4 +338,4 @@ contract Example {
 ---
         
 (source_file (contract_declaration (identifier) (contract_body (function_definition (identifier) (function_body 
-    (expression_statement (type_cast_expression (number_literal ))))))))
+    (expression_statement (type_cast_expression (primitive_type) (number_literal ))))))))

--- a/test/corpus/function.txt
+++ b/test/corpus/function.txt
@@ -33,7 +33,7 @@ contract Example {
     body: (contract_body 
         (function_definition
             function_name: (identifier) 
-            type: (type_name)
+            type: (type_name (primitive_type))
             name: (identifier)
             body: (function_body)))))
 
@@ -54,8 +54,8 @@ contract Example {
     body: (contract_body 
         (function_definition
             function_name: (identifier) 
-            type: (type_name)
-            type: (type_name)
+            type: (type_name (primitive_type))
+            type: (type_name (primitive_type))
             name: (identifier)
             body: (function_body)))))
 
@@ -81,8 +81,8 @@ contract Example {
             (visibility)
             (modifier_invocation (identifier))
             (virtual)
-            type: (type_name)
-            type: (type_name)
+            type: (type_name (primitive_type))
+            type: (type_name (primitive_type))
             name: (identifier)
             body: (function_body)))))
 

--- a/test/corpus/modifier.txt
+++ b/test/corpus/modifier.txt
@@ -31,7 +31,7 @@ contract Example {
     body: (contract_body 
         (modifier_definition 
             name: (identifier)
-            type: (type_name)
+            type: (type_name (primitive_type))
             name: (identifier)
             body: (function_body)))))
 

--- a/test/corpus/state_variable.txt
+++ b/test/corpus/state_variable.txt
@@ -13,7 +13,7 @@ contract StateVariable {
     name: (identifier)
     body: (contract_body 
         (state_variable_declaration 
-            type: (type_name)
+            type: (type_name (primitive_type))
             name: (identifier)))))
 
 ====================
@@ -31,7 +31,7 @@ contract StateVariable {
     name: (identifier)
     body: (contract_body 
         (state_variable_declaration 
-            type: (type_name)
+            type: (type_name (primitive_type))
             name:  (identifier) 
             value: (number_literal)))))
 
@@ -50,7 +50,7 @@ contract StateVariable {
     name: (identifier)
     body: (contract_body 
         (state_variable_declaration 
-            type: (type_name)
+            type: (type_name (primitive_type))
             (override_specifier (identifier) (identifier)) 
             name: (identifier) 
             value: (number_literal)))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -18,7 +18,7 @@ contract Example {
          function_name: (identifier)
          body: (function_body 
             (variable_declaration_statement (variable_declaration 
-                    (type_name (type_name)) 
+                    (type_name (type_name (primitive_type))) 
                     name: (identifier))))))))
 
 
@@ -78,7 +78,7 @@ contract Example {
 (source_file (contract_declaration (identifier) (contract_body (function_definition (identifier) 
     (function_body 
         (for_statement 
-            (variable_declaration_statement (variable_declaration (type_name) (identifier)) (number_literal)) 
+            (variable_declaration_statement (variable_declaration (type_name (primitive_type)) (identifier)) (number_literal)) 
             (expression_statement (update_expression (identifier)))
             (binary_expression (identifier) (number_literal)) 
             (expression_statement (update_expression (identifier))))
@@ -141,8 +141,8 @@ contract Example {
 
 ---
 (source_file (contract_declaration (identifier) (contract_body (function_definition (identifier) (function_body 
-    (try_statement (call_expresion (identifier)) (type_name) (identifier) (block_statement (expression_statement (update_expression (identifier))))
-    (catch_clause (identifier) (type_name) (identifier) (block_statement (expression_statement (update_expression (identifier)))))))))))
+    (try_statement (call_expression (identifier)) (type_name (primitive_type)) (identifier) (block_statement (expression_statement (update_expression (identifier))))
+    (catch_clause (identifier) (type_name (primitive_type)) (identifier) (block_statement (expression_statement (update_expression (identifier)))))))))))
 
 ====================
 Return statement
@@ -182,3 +182,12 @@ contract Example {
     }
 }
 ---
+(source_file 
+    (contract_declaration 
+        (identifier) 
+        (contract_body 
+            (function_definition 
+                (identifier) 
+                (function_body 
+                    (emit_statement 
+                    (identifier)))))))

--- a/test/corpus/struct.txt
+++ b/test/corpus/struct.txt
@@ -12,5 +12,5 @@ struct example {
 (source_file
     (struct_declaration 
         (identifier)
-        (struct_member (type_name) (identifier))
-        (struct_member (type_name) (identifier)))) 
+        (struct_member (type_name (primitive_type)) (identifier))
+        (struct_member (type_name (primitive_type)) (identifier)))) 

--- a/test/corpus/using.txt
+++ b/test/corpus/using.txt
@@ -31,4 +31,4 @@ contract Example {
     body: (contract_body 
       (using_directive 
         (type_alias (identifier) (identifier))
-        source: (type_name)))))
+        source: (type_name (primitive_type))))))


### PR DESCRIPTION
Hi @JoranHonig ! Thanks for your work.

I tried to use this package to add syntax highlight to neovim [nvim-treesitter/issues/1168](https://github.com/nvim-treesitter/nvim-treesitter/issues/1168) and it turned out that to support that we should add `queries/highlights.scm`. I tinkered a little bit and managed to produce something that I consider to be usable. 
You can see example here https://p13nty.xyz/tree-sitter-solidity-sample.html

There are some minor issues there but that can be changed later. For example, it does not detect built-ins properly. 


In order to do that I had to do one change to grammar (primitive_type is public now) so this piece of code is highlighted properly:
(line 689).
Without it I did not manage to separate e.g. `address` and `salt` from each other.
```solidity
contract C {
    function createDSalted(bytes32 salt, uint arg) public {
        /// This complicated expression just tells you how the address
        /// can be pre-computed. It is just there for illustration.
        /// You actually only need ``new D{salt: salt}(arg)``.
        address predictedAddress = address(bytes20(keccak256(abi.encodePacked(
            byte(0xff),
            address(this),
            salt,
            keccak256(abi.encodePacked(
                type(D).creationCode,
                arg
            ))
        ))));

        D d = new D{salt: salt}(arg);
        require(address(d) == predictedAddress);
    }
}
```

* `queries/highlights.scm` added and `package.json` changed to support
  syntax highlight
* primitive_type node made public for specific highlight case
* typo fixed in grammar definition
* grammar renamed 'Solidity' -> 'solidity' for consistency with other
  packages
* tree-sitter 0.19.4 is used to generate bindings for rust and node (can you publish package please?)