### PR TITLE
Block comments regex alternative

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -988,15 +988,16 @@ module.exports = grammar({
         ),
         
 
+        // https://github.com/tree-sitter/tree-sitter-c/blob/master/grammar.js#L965
         comment: $ => token(
-            prec(PREC.COMMENT, 
+            prec(PREC.COMMENT,
                 choice(
-                    seq('//', /.*/),
+                    seq('//', /(\\(.|\r?\n)|[^\\\n])*/),
                     seq(
                         '/*',
-                        /.*/,
-                        '*/'
-                    )       
+                        /[^*]*\*+([^/*][^*]*\*+)*/,
+                        '/'
+                    )
                 )
             )
         ),


### PR DESCRIPTION
The current grammar does not support block comments properly, the below is not recognized as a block comment:
```c
/**
 * @comment
 */
```
Since Solidity essentially uses C-style comments I copied the comment regex from [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c/blob/master/grammar.js#L965) which seems to be working.
