### PR TITLE
Name intermediate rules for semgrep

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -980,7 +980,7 @@ module.exports = grammar({
             seq(
             "'",
             repeat(choice(
-                _string_immediate_elt_inside_quote,
+                $._string_immediate_elt_inside_quote,
                 $._escape_sequence
             )),
             "'"

--- a/grammar.js
+++ b/grammar.js
@@ -972,7 +972,7 @@ module.exports = grammar({
             seq(
             '"',
             repeat(choice(
-                token.immediate(prec(PREC.STRING, /[^"\\\n]+|\\\r?\n/)),
+                $._string_immediate_elt_inside_double_quote,
                 $._escape_sequence
             )),
             '"'
@@ -980,12 +980,18 @@ module.exports = grammar({
             seq(
             "'",
             repeat(choice(
-                token.immediate(prec(PREC.STRING, /[^'\\\n]+|\\\r?\n/)),
+                _string_immediate_elt_inside_quote,
                 $._escape_sequence
             )),
             "'"
             )
         ),
+	    // We need to name those elts for ocaml-tree-sitter-semgrep.
+        _string_immediate_elt_inside_double_quote: $ =>
+            token.immediate(prec(PREC.STRING, /[^"\\\n]+|\\\r?\n/)),
+        _string_immediate_elt_inside_quote: $ =>
+            token.immediate(prec(PREC.STRING, /[^'\\\n]+|\\\r?\n/)),
+
         
 
         // Based on: https://github.com/tree-sitter/tree-sitter-c/blob/master/grammar.js#L965


### PR DESCRIPTION
This is a small change to the grammar that will allow ocaml-tree-sitter-semgrep to process the grammar (it currently does not handle rules using token.immediate in this way).
This will allow later to add support for solidity in semgrep.
