### PR TITLE
Highlights fix

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,11 +2,11 @@
 
 ; Pragma
 (pragma_directive) @tag
-;; (pragma_directive ">=" @tag)
-;; (pragma_directive "<=" @tag)
-;; (pragma_directive "=" @tag)
-;; (pragma_directive "~" @tag)
-;; (pragma_directive "^" @tag)
+(solidity_version_comparison_operator ">=" @tag)
+(solidity_version_comparison_operator "<=" @tag)
+(solidity_version_comparison_operator "=" @tag)
+(solidity_version_comparison_operator "~" @tag)
+(solidity_version_comparison_operator "^" @tag)
 
 
 ; Literals

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,11 +2,11 @@
 
 ; Pragma
 (pragma_directive) @tag
-(pragma_directive ">=" @tag)
-(pragma_directive "<=" @tag)
-(pragma_directive "=" @tag)
-(pragma_directive "~" @tag)
-(pragma_directive "^" @tag)
+;; (pragma_directive ">=" @tag)
+;; (pragma_directive "<=" @tag)
+;; (pragma_directive "=" @tag)
+;; (pragma_directive "~" @tag)
+;; (pragma_directive "^" @tag)
 
 
 ; Literals
@@ -35,7 +35,7 @@
 ; Color payable in payable address conversion as type and not as keyword
 (payable_conversion_expression "payable" @type)
 (emit_statement . (identifier) @type)
-; Handles ContractA, ContractB in function foo() override(ContractA, contractB) {} 
+; Handles ContractA, ContractB in function foo() override(ContractA, contractB) {}
 (override_specifier (identifier) @type)
 ; Ensures that delimiters in mapping( ... => .. ) are not colored like types
 (type_name "(" @punctuation.bracket "=>" @punctuation.delimiter ")" @punctuation.bracket)
@@ -66,7 +66,7 @@
 ; Function parameters
 (event_paramater name: (identifier) @variable.parameter)
 (function_definition
-  name:  (identifier) @variable.parameter)
+  function_name:  (identifier) @variable.parameter)
 
 ; Yul functions
 (yul_function_call function: (yul_identifier) @function)


### PR DESCRIPTION
Running `tree-sitter test` threw an error because of these queries. Now it is passing as expected.

Regarding the `pragma_directive` queries, I don't know why only those operators are queried. Maybe we can add the rest in this PR.

Let me know if I missed something.
Thanks!