### PR TITLE
update tree sitter crate minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19.5"
+tree-sitter = "0.20.9"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Without ticking the minor version, this error occurs:

```
.set_language(tree_sitter_solidity::language())
    |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `tree_sitter::Language`, found a different struct `tree_sitter::Language`
    |          |
    |          arguments to this function are incorrect
    |
    = note: perhaps two different versions of crate `tree_sitter` are being used?
```