### PR TITLE
update tree-sitter version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19.5"
+tree-sitter = "~0.20"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Had to [update for a PR to zed.dev](https://github.com/zed-industries/zed/pull/6847#issuecomment-1913753225). Not sure if it is something you want or if it will break existing integrations so didn't PR initially, but will let you decide.