### PR TITLE
fix(makefile): macOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.2.6
+VERSION := 1.2.10
 
 LANGUAGE_NAME := tree-sitter-solidity
 
@@ -21,8 +21,21 @@ TS ?= tree-sitter
 SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))
 SONAME_MINOR := $(word 2,$(subst ., ,$(VERSION)))
 
+# Detect OS and Architecture for HOMEBREW_PREFIX
+ifeq ($(shell uname -s),Darwin)
+  ifeq ($(shell uname -m),arm64)
+    # Apple Silicon
+    HOMEBREW_PREFIX ?= /opt/homebrew
+  else
+    # Intel
+    HOMEBREW_PREFIX ?= /usr/local
+  endif
+else
+  HOMEBREW_PREFIX ?= /usr/local
+endif
+
 # install directory layout
-PREFIX ?= /usr/local
+PREFIX ?= $(HOMEBREW_PREFIX)
 INCLUDEDIR ?= $(PREFIX)/include
 LIBDIR ?= $(PREFIX)/lib
 PCLIBDIR ?= $(LIBDIR)/pkgconfig
@@ -33,31 +46,29 @@ OBJS := $(patsubst %.c,%.o,$(wildcard $(SRC_DIR)/*.c))
 # flags
 ARFLAGS := rcs
 override CFLAGS += -I$(SRC_DIR) -std=c11 -fPIC
+LDFLAGS += -L$(LIBDIR)
 
 # OS-specific bits
 ifeq ($(OS),Windows_NT)
-	$(error "Windows is not supported")
+  $(error "Windows is not supported")
 else ifeq ($(shell uname),Darwin)
-	SOEXT = dylib
-	SOEXTVER_MAJOR = $(SONAME_MAJOR).dylib
-	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).dylib
-	LINKSHARED := $(LINKSHARED)-dynamiclib -Wl,
-	ifneq ($(ADDITIONAL_LIBS),)
-	LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS),
-	endif
-	LINKSHARED := $(LINKSHARED)-install_name,$(LIBDIR)/lib$(LANGUAGE_NAME).$(SONAME_MAJOR).dylib,-rpath,@executable_path/../Frameworks
+  SOEXT = dylib
+  SOEXTVER_MAJOR = $(SONAME_MAJOR).dylib
+  SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).dylib
+  LINKSHARED := $(LINKSHARED)-dynamiclib -Wl,
+  ifneq ($(ADDITIONAL_LIBS),)
+    LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS),
+  endif
+  LINKSHARED := $(LINKSHARED)-install_name,$(LIBDIR)/lib$(LANGUAGE_NAME).$(SONAME_MAJOR).dylib,-rpath,@executable_path/../Frameworks
 else
-	SOEXT = so
-	SOEXTVER_MAJOR = so.$(SONAME_MAJOR)
-	SOEXTVER = so.$(SONAME_MAJOR).$(SONAME_MINOR)
-	LINKSHARED := $(LINKSHARED)-shared -Wl,
-	ifneq ($(ADDITIONAL_LIBS),)
-	LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS)
-	endif
-	LINKSHARED := $(LINKSHARED)-soname,lib$(LANGUAGE_NAME).so.$(SONAME_MAJOR)
-endif
-ifneq ($(filter $(shell uname),FreeBSD NetBSD DragonFly),)
-	PCLIBDIR := $(PREFIX)/libdata/pkgconfig
+  SOEXT = so
+  SOEXTVER_MAJOR = so.$(SONAME_MAJOR)
+  SOEXTVER = so.$(SONAME_MAJOR).$(SONAME_MINOR)
+  LINKSHARED := $(LINKSHARED)-shared -Wl,
+  ifneq ($(ADDITIONAL_LIBS),)
+    LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS)
+  endif
+  LINKSHARED := $(LINKSHARED)-soname,lib$(LANGUAGE_NAME).so.$(SONAME_MAJOR)
 endif
 
 all: lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) $(LANGUAGE_NAME).pc

--- a/Makefile
+++ b/Makefile
@@ -21,21 +21,14 @@ TS ?= tree-sitter
 SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))
 SONAME_MINOR := $(word 2,$(subst ., ,$(VERSION)))
 
-# Detect OS and Architecture for HOMEBREW_PREFIX
-ifeq ($(shell uname -s),Darwin)
-  ifeq ($(shell uname -m),arm64)
-    # Apple Silicon
-    HOMEBREW_PREFIX ?= /opt/homebrew
-  else
-    # Intel
-    HOMEBREW_PREFIX ?= /usr/local
-  endif
-else
-  HOMEBREW_PREFIX ?= /usr/local
+# install directory layout
+
+# use alternative directory if home
+ifneq ("$(wildcard /opt/homebrew))", "")
+  PREFIX ?= /opt/homebrew
 endif
 
-# install directory layout
-PREFIX ?= $(HOMEBREW_PREFIX)
+PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include
 LIBDIR ?= $(PREFIX)/lib
 PCLIBDIR ?= $(LIBDIR)/pkgconfig

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SONAME_MINOR := $(word 2,$(subst ., ,$(VERSION)))
 
 # install directory layout
 
-# use alternative directory if home
+# use alternative directory if homebrew is installed
 ifneq ("$(wildcard /opt/homebrew))", "")
   PREFIX ?= /opt/homebrew
 endif


### PR DESCRIPTION
This correctly installs the dylib for macOS ARM and Intel makes.

Previously we encountered the error:
```bash
install -d '/usr/local/include'/tree_sitter '/usr/local/lib/pkgconfig' '/usr/local/lib'
install: mkdir /usr/local/include/tree_sitter: Permission denied
make: *** [install] Error 71
```

We now correctly get:
```bash
$ make install
install -d '/opt/homebrew/include'/tree_sitter '/opt/homebrew/lib/pkgconfig' '/opt/homebrew/lib'
install -m644 bindings/c/tree-sitter-solidity.h '/opt/homebrew/include'/tree_sitter/tree-sitter-solidity.h
install -m644 tree-sitter-solidity.pc '/opt/homebrew/lib/pkgconfig'/tree-sitter-solidity.pc
install -m644 libtree-sitter-solidity.a '/opt/homebrew/lib'/libtree-sitter-solidity.a
install -m755 libtree-sitter-solidity.dylib '/opt/homebrew/lib'/libtree-sitter-solidity.1.2.dylib
ln -sf libtree-sitter-solidity.1.2.dylib '/opt/homebrew/lib'/libtree-sitter-solidity.1.dylib
ln -sf libtree-sitter-solidity.1.dylib '/opt/homebrew/lib'/libtree-sitter-solidity.dylib
```