### PR TITLE
feat: add type hinting in editor support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,5 @@
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
 // Precedence is used by the parser to determine which rule to apply when there are two rules that can be applied.
 // We use the PREC dict to globally define rule precedence
 // [N] corresponds to precedence table at https://docs.soliditylang.org/en/v0.8.24/cheatsheet.html#order-of-precedence-of-operators


### PR DESCRIPTION
Adds support for your editor to provide documentation and type information as you edit the grammar.

```typescript
/// <reference types="tree-sitter-cli/dsl" />
// @ts-check
```

reference: [https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started](https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html?highlight=%2F%2F%2F%20%3Creference%20types%3D%22tree-sitter-cli%2Fdsl%22%20%2F%3E%20%2F%2F%20%40ts-check#generate)